### PR TITLE
App launch work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+open-runner-api/.classpath
+open-runner-api/.settings/org.eclipse.jdt.apt.core.prefs
+open-runner-api/.settings/org.eclipse.jdt.core.prefs
+open-runner-timer/.classpath
+open-runner-timer/.project

--- a/open-runner-timer/src/main/java/org/open/OpenRunner.java
+++ b/open-runner-timer/src/main/java/org/open/OpenRunner.java
@@ -1,0 +1,15 @@
+package org.open;
+
+import org.open.runner.timer.MainApplication;
+
+import javafx.application.Application;
+
+/**
+ * Main entry point for the OpenRunnerTimer application.
+ */
+public class OpenRunner {
+
+    public static void main(String[] args) {
+        new Thread(() -> Application.launch(MainApplication.class)).start();
+    }
+}

--- a/open-runner-timer/src/main/java/org/open/runner/timer/MainApplication.java
+++ b/open-runner-timer/src/main/java/org/open/runner/timer/MainApplication.java
@@ -8,10 +8,6 @@ public class MainApplication extends Application {
 
 	private MainController controller;
 
-	public static void main(final String[] args) {
-		Application.launch(args);
-	}
-
 	@Override
 	public void init() throws Exception {
 		controller = new MainController();

--- a/open-runner-timer/src/main/java/org/open/runner/timer/OpenRunner.java
+++ b/open-runner-timer/src/main/java/org/open/runner/timer/OpenRunner.java
@@ -1,6 +1,4 @@
-package org.open;
-
-import org.open.runner.timer.MainApplication;
+package org.open.runner.timer;
 
 import javafx.application.Application;
 


### PR DESCRIPTION
I've created a new main class called `OpenRunner.java` which will bootstrap the launch of the JavaFx application into a new thread, meaning you no longer need openjfx libraries installed.

I've also added some eclispe settings to the gitignore, and will remove the files later.